### PR TITLE
chore: parameterize synth to prepare for additional versions

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/__init__.py
+++ b/google/cloud/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/bigquery_storage.py
+++ b/google/cloud/bigquery_storage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py
+++ b/google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/bigquery_storage_v1beta1/gapic/enums.py
+++ b/google/cloud/bigquery_storage_v1beta1/gapic/enums.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
+++ b/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py
+++ b/google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py
@@ -1258,7 +1258,8 @@ Stream = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_STREAM,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""Information about a single data stream within a read session.
+        __doc__="""Information about a single data stream within a read
+  session.
   
   
   Attributes:
@@ -1277,7 +1278,8 @@ StreamPosition = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_STREAMPOSITION,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""Expresses a point within a given stream using an offset position.
+        __doc__="""Expresses a point within a given stream using an offset
+  position.
   
   
   Attributes:
@@ -1336,8 +1338,9 @@ CreateReadSessionRequest = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_CREATEREADSESSIONREQUEST,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""Creates a new read session, which may include additional options such as
-  requested parallelism, projection filters and constraints.
+        __doc__="""Creates a new read session, which may include additional
+  options such as requested parallelism, projection filters and
+  constraints.
   
   
   Attributes:
@@ -1377,8 +1380,8 @@ ReadRowsRequest = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_READROWSREQUEST,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""Requesting row data via ``ReadRows`` must provide Stream position
-  information.
+        __doc__="""Requesting row data via ``ReadRows`` must provide Stream
+  position information.
   
   
   Attributes:
@@ -1468,7 +1471,8 @@ ThrottleStatus = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_THROTTLESTATUS,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""Information on if the current connection is being throttled.
+        __doc__="""Information on if the current connection is being
+  throttled.
   
   
   Attributes:
@@ -1487,8 +1491,8 @@ ReadRowsResponse = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_READROWSRESPONSE,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""Response from calling ``ReadRows`` may include row data, progress and
-  throttling information.
+        __doc__="""Response from calling ``ReadRows`` may include row data,
+  progress and throttling information.
   
   
   Attributes:
@@ -1522,8 +1526,8 @@ BatchCreateReadSessionStreamsRequest = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_BATCHCREATEREADSESSIONSTREAMSREQUEST,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""Information needed to request additional streams for an established read
-  session.
+        __doc__="""Information needed to request additional streams for an
+  established read session.
   
   
   Attributes:
@@ -1546,8 +1550,8 @@ BatchCreateReadSessionStreamsResponse = _reflection.GeneratedProtocolMessageType
     dict(
         DESCRIPTOR=_BATCHCREATEREADSESSIONSTREAMSRESPONSE,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.storage_pb2",
-        __doc__="""The response from ``BatchCreateReadSessionStreams`` returns the stream
-  identifiers for the newly created streams.
+        __doc__="""The response from ``BatchCreateReadSessionStreams``
+  returns the stream identifiers for the newly created streams.
   
   
   Attributes:

--- a/google/cloud/bigquery_storage_v1beta1/proto/table_reference_pb2.py
+++ b/google/cloud/bigquery_storage_v1beta1/proto/table_reference_pb2.py
@@ -162,8 +162,8 @@ TableReference = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_TABLEREFERENCE,
         __module__="google.cloud.bigquery.storage_v1beta1.proto.table_reference_pb2",
-        __doc__="""Table reference that includes just the 3 strings needed to identify a
-  table.
+        __doc__="""Table reference that includes just the 3 strings needed to
+  identify a table.
   
   
   Attributes:

--- a/google/cloud/bigquery_storage_v1beta1/types.py
+++ b/google/cloud/bigquery_storage_v1beta1/types.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2020-02-12T17:57:12.212806Z",
+  "updateTime": "2020-02-12T18:06:09.446329Z",
   "sources": [
     {
       "generator": {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2020-02-05T11:24:26.438304Z",
+  "updateTime": "2020-02-12T17:57:12.212806Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.44.4",
-        "dockerImage": "googleapis/artman@sha256:19e945954fc960a4bdfee6cb34695898ab21a8cf0bac063ee39b91f00a1faec8"
+        "version": "0.45.0",
+        "dockerImage": "googleapis/artman@sha256:6aec9c34db0e4be221cdaf6faba27bdc07cfea846808b3d3b964dfce3a9a0f9b"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a8ed9d921fdddc61d8467bfd7c1668f0ad90435c",
-        "internalRef": "293257997"
+        "sha": "efd36705972cfcd7d00ab4c6dfa1135bafacd4ae",
+        "internalRef": "294664231"
       }
     },
     {
       "template": {
         "name": "python_split_library",
         "origin": "synthtool.gcp",
-        "version": "2019.10.17"
+        "version": "2020.2.4"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -19,112 +19,115 @@ from synthtool import gcp
 
 gapic = gcp.GAPICGenerator()
 common = gcp.CommonTemplates()
-version = "v1beta1"
+versions = ["v1beta1"]
 
-library = gapic.py_library(
-    "bigquery_storage",
-    version,
-    config_path="/google/cloud/bigquery/storage/" "artman_bigquerystorage_v1beta1.yaml",
-    artman_output_name="bigquerystorage-v1beta1",
-    include_protos=True,
-)
 
-s.move(
-    library,
-    excludes=[
-        "docs/conf.py",
-        "docs/index.rst",
-        "google/cloud/bigquery_storage_v1beta1/__init__.py",
-        "README.rst",
-        "nox*.py",
-        "setup.py",
-        "setup.cfg",
-    ],
-)
+for version in versions:
 
-s.replace(
-    [
-        "google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py",
-        "google/cloud/bigquery_storage_v1beta1/proto/storage_pb2_grpc.py",
-    ],
-    "from google.cloud.bigquery.storage_v1beta1.proto",
-    "from google.cloud.bigquery_storage_v1beta1.proto",
-)
+    library = gapic.py_library(
+        "bigquery_storage",
+        version,
+        config_path="/google/cloud/bigquery/storage/" f"artman_bigquerystorage_{version}.yaml",
+        artman_output_name=f"bigquerystorage-{version}",
+        include_protos=True,
+    )
 
-s.replace(
-    "google/cloud/bigquery_storage_v1beta1/gapic/" "big_query_storage_client.py",
-    "google-cloud-bigquerystorage",
-    "google-cloud-bigquery-storage",
-)
+    s.move(
+        library,
+        excludes=[
+            "docs/conf.py",
+            "docs/index.rst",
+            f"google/cloud/bigquery_storage_{version}/__init__.py",
+            "README.rst",
+            "nox*.py",
+            "setup.py",
+            "setup.cfg",
+        ],
+    )
 
-s.replace(
-    "google/cloud/bigquery_storage_v1beta1/gapic/" "big_query_storage_client.py",
-    "import google.api_core.gapic_v1.method\n",
-    "\g<0>import google.api_core.path_template\n",
-)
+    s.replace(
+        [
+            f"google/cloud/bigquery_storage_{version}/proto/storage_pb2.py",
+            f"google/cloud/bigquery_storage_{version}/proto/storage_pb2_grpc.py",
+        ],
+        f"from google.cloud.bigquery.storage_{version}.proto",
+        f"from google.cloud.bigquery_storage_{version}.proto",
+    )
 
-s.replace(
-    ["tests/unit/gapic/v1beta1/test_big_query_storage_client_v1beta1.py"],
-    "from google.cloud import bigquery_storage_v1beta1",
-    "from google.cloud.bigquery_storage_v1beta1.gapic import big_query_storage_client  # noqa",
-)
+    s.replace(
+        f"google/cloud/bigquery_storage_{version}/gapic/" "big_query_storage_client.py",
+        "google-cloud-bigquerystorage",
+        "google-cloud-bigquery-storage",
+    )
 
-s.replace(
-    ["tests/unit/gapic/v1beta1/test_big_query_storage_client_v1beta1.py"],
-    "bigquery_storage_v1beta1.BigQueryStorageClient",
-    "big_query_storage_client.BigQueryStorageClient",
-)
+    s.replace(
+        f"google/cloud/bigquery_storage_{version}/gapic/" "big_query_storage_client.py",
+        "import google.api_core.gapic_v1.method\n",
+        "\g<0>import google.api_core.path_template\n",
+    )
 
-# START: Ignore lint and coverage
-s.replace(
-    ["google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py"],
-    "if transport:",
-    "if transport:  # pragma: no cover",
-)
+    s.replace(
+        [f"tests/unit/gapic/{version}/test_big_query_storage_client_{version}.py"],
+        f"from google.cloud import bigquery_storage_{version}",
+        f"from google.cloud.bigquery_storage_{version}.gapic import big_query_storage_client  # noqa",
+    )
 
-s.replace(
-    ["google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py"],
-    r"to_grpc_metadata\(\n",
-    "to_grpc_metadata(  # pragma: no cover\n",
-)
+    s.replace(
+        [f"tests/unit/gapic/{version}/test_big_query_storage_client_{version}.py"],
+        "bigquery_storage_v1beta1.BigQueryStorageClient",
+        "big_query_storage_client.BigQueryStorageClient",
+    )
 
-s.replace(
-    ["google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py"],
-    r"metadata.append\(routing_metadata\)",
-    "metadata.append(routing_metadata)  # pragma: no cover",
-)
+    # START: Ignore lint and coverage
+    s.replace(
+        [f"google/cloud/bigquery_storage_{version}/gapic/big_query_storage_client.py"],
+        "if transport:",
+        "if transport:  # pragma: no cover",
+    )
 
-s.replace(
-    [
-        "google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py"
-    ],
-    "if channel is not None and credentials is not None:",
-    "if channel is not None and credentials is not None:  # pragma: no cover",
-)
+    s.replace(
+        [f"google/cloud/bigquery_storage_{version}/gapic/big_query_storage_client.py"],
+        r"to_grpc_metadata\(\n",
+        "to_grpc_metadata(  # pragma: no cover\n",
+    )
 
-s.replace(
-    [
-        "google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py"
-    ],
-    "if channel is None:",
-    "if channel is None:  # pragma: no cover",
-)
+    s.replace(
+        [f"google/cloud/bigquery_storage_{version}/gapic/big_query_storage_client.py"],
+        r"metadata.append\(routing_metadata\)",
+        "metadata.append(routing_metadata)  # pragma: no cover",
+    )
 
-s.replace(
-    [
-        "google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py"
-    ],
-    r"google.api_core.grpc_helpers.create_channel\(",
-    "google.api_core.grpc_helpers.create_channel(  # pragma: no cover",
-)
+    s.replace(
+        [
+            f"google/cloud/bigquery_storage_{version}/gapic/transports/big_query_storage_grpc_transport.py"
+        ],
+        "if channel is not None and credentials is not None:",
+        "if channel is not None and credentials is not None:  # pragma: no cover",
+    )
 
-# Fix up proto docs that are missing summary line.
-s.replace(
-    "google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py",
-    '"""Attributes:',
-    '"""Protocol buffer.\n\n  Attributes:',
-)
-# END: Ignore lint and coverage
+    s.replace(
+        [
+            f"google/cloud/bigquery_storage_{version}/gapic/transports/big_query_storage_grpc_transport.py"
+        ],
+        "if channel is None:",
+        "if channel is None:  # pragma: no cover",
+    )
+
+    s.replace(
+        [
+            f"google/cloud/bigquery_storage_{version}/gapic/transports/big_query_storage_grpc_transport.py"
+        ],
+        r"google.api_core.grpc_helpers.create_channel\(",
+        "google.api_core.grpc_helpers.create_channel(  # pragma: no cover",
+    )
+
+    # Fix up proto docs that are missing summary line.
+    s.replace(
+        f"google/cloud/bigquery_storage_{version}/proto/storage_pb2.py",
+        '"""Attributes:',
+        '"""Protocol buffer.\n\n  Attributes:',
+    )
+    # END: Ignore lint and coverage
 
 # ----------------------------------------------------------------------------
 # Add templated files

--- a/synth.py
+++ b/synth.py
@@ -87,12 +87,6 @@ for version in versions:
 
     s.replace(
         [f"google/cloud/bigquery_storage_{version}/gapic/big_query_storage_client.py"],
-        r"to_grpc_metadata\(\n",
-        "to_grpc_metadata(  # pragma: no cover\n",
-    )
-
-    s.replace(
-        [f"google/cloud/bigquery_storage_{version}/gapic/big_query_storage_client.py"],
         r"metadata.append\(routing_metadata\)",
         "metadata.append(routing_metadata)  # pragma: no cover",
     )
@@ -128,6 +122,7 @@ for version in versions:
         '"""Protocol buffer.\n\n  Attributes:',
     )
     # END: Ignore lint and coverage
+
 
 # ----------------------------------------------------------------------------
 # Add templated files

--- a/tests/unit/gapic/v1beta1/test_big_query_storage_client_v1beta1.py
+++ b/tests/unit/gapic/v1beta1/test_big_query_storage_client_v1beta1.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION

This PR refactors the synthfile to prepare for future generation of multiple versions of the bigquerystorage API endpoints.  It does not include them, but it does fully parameterize the single library.

It removes this unnecessary replacement that was warning as being unused before this change:

s.replace(
    ["google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py"],
    r"to_grpc_metadata\(\n",
    "to_grpc_metadata(  # pragma: no cover\n",
)

It also includes the output from running synthtool, which appears to simply have changed comment formatting.