### PR TITLE
docs: fix typo in storage quickstart comment

### DIFF
--- a/docs/gapic/v1/types.rst
+++ b/docs/gapic/v1/types.rst
@@ -3,3 +3,4 @@ Types for BigQuery Storage API Client
 
 .. automodule:: google.cloud.bigquery_storage_v1.types
     :members:
+    :noindex:

--- a/docs/gapic/v1beta1/types.rst
+++ b/docs/gapic/v1beta1/types.rst
@@ -3,3 +3,4 @@ Types for BigQuery Storage API Client
 
 .. automodule:: google.cloud.bigquery_storage_v1beta1.types
     :members:
+    :noindex:

--- a/docs/gapic/v1beta2/types.rst
+++ b/docs/gapic/v1beta2/types.rst
@@ -3,3 +3,4 @@ Types for BigQuery Storage API Client
 
 .. automodule:: google.cloud.bigquery_storage_v1beta2.types
     :members:
+    :noindex:

--- a/samples/quickstart.py
+++ b/samples/quickstart.py
@@ -65,7 +65,7 @@ def main(project_id="your-project-id", snapshot_millis=0):
     reader = client.read_rows(session.streams[0].name)
 
     # The read stream contains blocks of Avro-encoded bytes. The rows() method
-    # uses the fastavro library to parse these blocks as an interable of Python
+    # uses the fastavro library to parse these blocks as an iterable of Python
     # dictionaries. Install fastavro with the following command:
     #
     # pip install google-cloud-bigquery-storage[fastavro]


### PR DESCRIPTION
TL;DR

s/interable/iterable/

This also addresses some failures in the docs target as warnings are treated as errors.  Indicating noindex for duplicate definitions should address docs issues.