### PR TITLE
test: fix unit tests affected by pyarrow changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ dependencies = [
 extras = {
     "pandas": "pandas>=0.17.1",
     "fastavro": "fastavro>=0.21.2",
-    "pyarrow": "pyarrow>=0.13.0, != 0.14.0",
+    "pyarrow": "pyarrow>=0.15.0",
 }
 
 package_root = os.path.abspath(os.path.dirname(__file__))

--- a/tests/unit/test_reader_v1.py
+++ b/tests/unit/test_reader_v1.py
@@ -236,7 +236,6 @@ def _bq_to_arrow_schema(bq_columns):
         metadata = None
         if column.get("description") is not None:
             metadata = {"description": column.get("description")}
-        doc = column.get("description")
         name = column["name"]
         type_ = BQ_TO_ARROW_TYPES[column["type"]]
         mode = column.get("mode", "nullable").lower()

--- a/tests/unit/test_reader_v1.py
+++ b/tests/unit/test_reader_v1.py
@@ -233,12 +233,15 @@ def _bq_to_avro_schema(bq_columns):
 
 def _bq_to_arrow_schema(bq_columns):
     def bq_col_as_field(column):
+        metadata = None
+        if column.get("description") is not None:
+            metadata = {"description": column.get("description")}
         doc = column.get("description")
         name = column["name"]
         type_ = BQ_TO_ARROW_TYPES[column["type"]]
         mode = column.get("mode", "nullable").lower()
 
-        return pyarrow.field(name, type_, mode == "nullable", {"description": doc})
+        return pyarrow.field(name, type_, mode == "nullable", metadata)
 
     return pyarrow.schema(bq_col_as_field(c) for c in bq_columns)
 

--- a/tests/unit/test_reader_v1beta1.py
+++ b/tests/unit/test_reader_v1beta1.py
@@ -234,12 +234,15 @@ def _bq_to_avro_schema(bq_columns):
 
 def _bq_to_arrow_schema(bq_columns):
     def bq_col_as_field(column):
+        metadata = None
+        if column.get("description") is not None:
+            metadata = {"description": column.get("description")}
         doc = column.get("description")
         name = column["name"]
         type_ = BQ_TO_ARROW_TYPES[column["type"]]
         mode = column.get("mode", "nullable").lower()
 
-        return pyarrow.field(name, type_, mode == "nullable", {"description": doc})
+        return pyarrow.field(name, type_, mode == "nullable", metadata)
 
     return pyarrow.schema(bq_col_as_field(c) for c in bq_columns)
 

--- a/tests/unit/test_reader_v1beta1.py
+++ b/tests/unit/test_reader_v1beta1.py
@@ -237,7 +237,6 @@ def _bq_to_arrow_schema(bq_columns):
         metadata = None
         if column.get("description") is not None:
             metadata = {"description": column.get("description")}
-        doc = column.get("description")
         name = column["name"]
         type_ = BQ_TO_ARROW_TYPES[column["type"]]
         mode = column.get("mode", "nullable").lower()


### PR DESCRIPTION
Previously, tests attempted to set field metadata in cases where there
was no metadata values to communicate.  Changes in pyarrow consider this
invalid as there's an expectation that metadata should be coercable to
bytes.

This change alters testing behavior to only propagate column
description metadata when it is present.
