### PR TITLE
docs: fix read_rows() docstring sample

### DIFF
--- a/google/cloud/bigquery_storage_v1/client.py
+++ b/google/cloud/bigquery_storage_v1/client.py
@@ -74,11 +74,16 @@ class BigQueryReadClient(big_query_read_client.BigQueryReadClient):
             >>> # TODO: Initialize `parent`:
             >>> parent = 'projects/your-billing-project-id'
             >>>
-            >>> session = client.create_read_session(table, parent)
-            >>> stream=session.streams[0],  # TODO: Read the other streams.
-            ...
+            >>> requested_session = bigquery_storage_v1.types.ReadSession(
+            ...     table=table,
+            ...     data_format=bigquery_storage_v1.enums.DataFormat.AVRO,
+            ... )
+            >>> session = client.create_read_session(parent, requested_session)
             >>>
-            >>> for element in client.read_rows(stream):
+            >>> stream = session.streams[0],  # TODO: Also read any other streams.
+            >>> read_rows_stream = client.read_rows(stream.name)
+            >>>
+            >>> for element in read_rows_stream.rows(session):
             ...     # process element
             ...     pass
 


### PR DESCRIPTION
Fixes #38. 🦕

This PR fixes the code sample in the `read_rows()` method docstring. The old sample was written for the `v1beta1` client version.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


