### PR TITLE
Adds ability to pass through additional options to transport.

### DIFF
--- a/google/cloud/bigquery_storage_v1/gapic/transports/big_query_read_grpc_transport.py
+++ b/google/cloud/bigquery_storage_v1/gapic/transports/big_query_read_grpc_transport.py
@@ -42,6 +42,7 @@ class BigQueryReadGrpcTransport(object):
         channel=None,
         credentials=None,
         address="bigquerystorage.googleapis.com:443",
+        options=None,
     ):
         """Instantiate the transport class.
 
@@ -64,14 +65,13 @@ class BigQueryReadGrpcTransport(object):
             )
 
         # Create the channel.
+        if options is None:
+            options = {}
+        options["grpc.max_send_message_length"] = -1
+        options["grpc.max_receive_message_length"] = -1
         if channel is None:  # pragma: no cover
             channel = self.create_channel(
-                address=address,
-                credentials=credentials,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                }.items(),
+                address=address, credentials=credentials, options=options.items(),
             )
 
         self._channel = channel


### PR DESCRIPTION
This is mainly useful for forcing additional sub-channels to be
created which can increase throughput for read rows calls.

A proof of concept
(https://github.com/emkornfield/python-bigquery/tree/duplicate_streams)
shows someplace between 15-25% reduction in latency for to_dataframe
calls on the bigquery client for a 3GB table (3 streams).  Using
nload, the peak throughput the existing code gets is ~500 Mbit/s
with multiple channels we peak at ~1Gbit/s.


Fixes #46 