### PR TITLE
docs: pandas DataFrame samples are more standalone

### DIFF
--- a/samples/conftest.py
+++ b/samples/conftest.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def project_id():
+    return os.environ["GOOGLE_CLOUD_PROJECT"]
+

--- a/samples/conftest.py
+++ b/samples/conftest.py
@@ -20,4 +20,3 @@ import pytest
 @pytest.fixture(scope="session")
 def project_id():
     return os.environ["GOOGLE_CLOUD_PROJECT"]
-

--- a/samples/quickstart/quickstart_test.py
+++ b/samples/quickstart/quickstart_test.py
@@ -27,11 +27,6 @@ def now_millis():
     )
 
 
-@pytest.fixture()
-def project_id():
-    return os.environ["GOOGLE_CLOUD_PROJECT"]
-
-
 def test_quickstart_wo_snapshot(capsys, project_id):
     quickstart.main(project_id)
     out, _ = capsys.readouterr()

--- a/samples/quickstart/quickstart_test.py
+++ b/samples/quickstart/quickstart_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import datetime
-import os
-
-import pytest
 
 from . import quickstart
 

--- a/samples/to_dataframe/main_test.py
+++ b/samples/to_dataframe/main_test.py
@@ -31,7 +31,10 @@ def clients():
     )
 
     # Make clients.
-    bqclient = bigquery.Client(credentials=credentials, project=your_project_id,)
+    bqclient = bigquery.Client(
+        credentials=credentials,
+        project=your_project_id,
+    )
     bqstorageclient = bigquery_storage.BigQueryReadClient(credentials=credentials)
     # [END bigquerystorage_pandas_tutorial_create_client]
     # [END bigquerystorage_pandas_tutorial_all]
@@ -124,7 +127,9 @@ def test_session_to_dataframe(capsys, clients):
         read_options=read_options,
     )
     read_session = bqstorageclient.create_read_session(
-        parent=parent, read_session=requested_session, max_stream_count=1,
+        parent=parent,
+        read_session=requested_session,
+        max_stream_count=1,
     )
 
     # This example reads from only a single stream. Read from multiple streams

--- a/samples/to_dataframe/main_test.py
+++ b/samples/to_dataframe/main_test.py
@@ -31,10 +31,7 @@ def clients():
     )
 
     # Make clients.
-    bqclient = bigquery.Client(
-        credentials=credentials,
-        project=your_project_id,
-    )
+    bqclient = bigquery.Client(credentials=credentials, project=your_project_id,)
     bqstorageclient = bigquery_storage.BigQueryReadClient(credentials=credentials)
     # [END bigquerystorage_pandas_tutorial_create_client]
     # [END bigquerystorage_pandas_tutorial_all]
@@ -127,9 +124,7 @@ def test_session_to_dataframe(capsys, clients):
         read_options=read_options,
     )
     read_session = bqstorageclient.create_read_session(
-        parent=parent,
-        read_session=requested_session,
-        max_stream_count=1,
+        parent=parent, read_session=requested_session, max_stream_count=1,
     )
 
     # This example reads from only a single stream. Read from multiple streams

--- a/samples/to_dataframe/noxfile.py
+++ b/samples/to_dataframe/noxfile.py
@@ -226,7 +226,7 @@ def py(session: nox.sessions.Session) -> None:
 
 
 def _get_repo_root() -> Optional[str]:
-    """ Returns the root folder of the project. """
+    """Returns the root folder of the project."""
     # Get root of this repository. Assume we don't have directories nested deeper than 10 items.
     p = Path(os.getcwd())
     for i in range(10):

--- a/samples/to_dataframe/read_query_results.py
+++ b/samples/to_dataframe/read_query_results.py
@@ -1,0 +1,47 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def read_query_results():
+    # [START bigquerystorage_pandas_tutorial_read_query_results]
+    from google.cloud import bigquery
+
+    bqclient = bigquery.Client()
+
+    # Download query results.
+    query_string = """
+    SELECT
+    CONCAT(
+        'https://stackoverflow.com/questions/',
+        CAST(id as STRING)) as url,
+    view_count
+    FROM `bigquery-public-data.stackoverflow.posts_questions`
+    WHERE tags like '%google-bigquery%'
+    ORDER BY view_count DESC
+    """
+
+    dataframe = (
+        bqclient.query(query_string)
+        .result()
+        .to_dataframe(
+            # Optionally, explicitly request to use the BigQuery Storage API. As of
+            # google-cloud-bigquery version 1.26.0 and above, the BigQuery Storage
+            # API is used by default.
+            create_bqstorage_client=True,
+        )
+    )
+    print(dataframe.head())
+    # [END bigquerystorage_pandas_tutorial_read_query_results
+
+    return dataframe

--- a/samples/to_dataframe/read_query_results.py
+++ b/samples/to_dataframe/read_query_results.py
@@ -42,6 +42,6 @@ def read_query_results():
         )
     )
     print(dataframe.head())
-    # [END bigquerystorage_pandas_tutorial_read_query_result]
+    # [END bigquerystorage_pandas_tutorial_read_query_results]
 
     return dataframe

--- a/samples/to_dataframe/read_query_results.py
+++ b/samples/to_dataframe/read_query_results.py
@@ -42,6 +42,6 @@ def read_query_results():
         )
     )
     print(dataframe.head())
-    # [END bigquerystorage_pandas_tutorial_read_query_results
+    # [END bigquerystorage_pandas_tutorial_read_query_result]
 
     return dataframe

--- a/samples/to_dataframe/read_query_results_test.py
+++ b/samples/to_dataframe/read_query_results_test.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import read_query_results
+
+
+def test_read_query_results(capsys):
+    read_query_results.read_query_results()
+    out, _ = capsys.readouterr()
+    assert "stackoverflow" in out

--- a/samples/to_dataframe/read_table_bigquery.py
+++ b/samples/to_dataframe/read_table_bigquery.py
@@ -1,0 +1,42 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def read_table():
+    # [START bigquerystorage_pandas_tutorial_read_table]
+    from google.cloud import bigquery
+
+    bqclient = bigquery.Client()
+
+    # Download a table.
+    table = bigquery.TableReference.from_string(
+        "bigquery-public-data.utility_us.country_code_iso"
+    )
+    rows = bqclient.list_rows(
+        table,
+        selected_fields=[
+            bigquery.SchemaField("country_name", "STRING"),
+            bigquery.SchemaField("fips_code", "STRING"),
+        ],
+    )
+    dataframe = rows.to_dataframe(
+        # Optionally, explicitly request to use the BigQuery Storage API. As of
+        # google-cloud-bigquery version 1.26.0 and above, the BigQuery Storage
+        # API is used by default.
+        create_bqstorage_client=True,
+    )
+    print(dataframe.head())
+    # [END bigquerystorage_pandas_tutorial_read_table]
+
+    return dataframe

--- a/samples/to_dataframe/read_table_bigquery_test.py
+++ b/samples/to_dataframe/read_table_bigquery_test.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import read_table_bigquery
+
+
+def test_read_table(capsys):
+    read_table_bigquery.read_table()
+    out, _ = capsys.readouterr()
+    assert "country_name" in out

--- a/samples/to_dataframe/read_table_bqstorage.py
+++ b/samples/to_dataframe/read_table_bqstorage.py
@@ -23,6 +23,7 @@ def read_table(your_project_id):
     # [START bigquerystorage_pandas_tutorial_read_session]
     from google.cloud import bigquery_storage
     from google.cloud.bigquery_storage import types
+    import pandas
 
     bqstorageclient = bigquery_storage.BigQueryReadClient()
 
@@ -57,9 +58,11 @@ def read_table(your_project_id):
     stream = read_session.streams[0]
     reader = bqstorageclient.read_rows(stream.name)
 
-    # Parse all Arrow blocks and create a dataframe. This call requires a
-    # session, because the session contains the schema for the row blocks.
-    dataframe = reader.to_dataframe(read_session)
+    # Parse all Arrow blocks and create a dataframe.
+    frames = []
+    for message in reader.rows().pages:
+        frames.append(message.to_dataframe())
+    dataframe = pandas.concat(frames)
     print(dataframe.head())
     # [END bigquerystorage_pandas_tutorial_read_session]
 

--- a/samples/to_dataframe/read_table_bqstorage.py
+++ b/samples/to_dataframe/read_table_bqstorage.py
@@ -48,9 +48,7 @@ def read_table(your_project_id):
         read_options=read_options,
     )
     read_session = bqstorageclient.create_read_session(
-        parent=parent,
-        read_session=requested_session,
-        max_stream_count=1,
+        parent=parent, read_session=requested_session, max_stream_count=1,
     )
 
     # This example reads from only a single stream. Read from multiple streams

--- a/samples/to_dataframe/read_table_bqstorage.py
+++ b/samples/to_dataframe/read_table_bqstorage.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def read_table(your_project_id):
+    original_your_project_id = your_project_id
+    # [START bigquerystorage_pandas_tutorial_read_session]
+    your_project_id = "project-for-read-session"
+    # [END bigquerystorage_pandas_tutorial_read_session]
+    your_project_id = original_your_project_id
+
+    # [START bigquerystorage_pandas_tutorial_read_session]
+    from google.cloud import bigquery_storage
+    from google.cloud.bigquery_storage import types
+
+    bqstorageclient = bigquery_storage.BigQueryReadClient()
+
+    project_id = "bigquery-public-data"
+    dataset_id = "new_york_trees"
+    table_id = "tree_species"
+    table = f"projects/{project_id}/datasets/{dataset_id}/tables/{table_id}"
+
+    # Select columns to read with read options. If no read options are
+    # specified, the whole table is read.
+    read_options = types.ReadSession.TableReadOptions(
+        selected_fields=["species_common_name", "fall_color"]
+    )
+
+    parent = "projects/{}".format(your_project_id)
+
+    requested_session = types.ReadSession(
+        table=table,
+        # Avro is also supported, but the Arrow data format is optimized to
+        # work well with column-oriented data structures such as pandas
+        # DataFrames.
+        data_format=types.DataFormat.ARROW,
+        read_options=read_options,
+    )
+    read_session = bqstorageclient.create_read_session(
+        parent=parent,
+        read_session=requested_session,
+        max_stream_count=1,
+    )
+
+    # This example reads from only a single stream. Read from multiple streams
+    # to fetch data faster. Note that the session may not contain any streams
+    # if there are no rows to read.
+    stream = read_session.streams[0]
+    reader = bqstorageclient.read_rows(stream.name)
+
+    # Parse all Arrow blocks and create a dataframe. This call requires a
+    # session, because the session contains the schema for the row blocks.
+    dataframe = reader.to_dataframe(read_session)
+    print(dataframe.head())
+    # [END bigquerystorage_pandas_tutorial_read_session]
+
+    return dataframe

--- a/samples/to_dataframe/read_table_bqstorage_test.py
+++ b/samples/to_dataframe/read_table_bqstorage_test.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import read_table_bqstorage
+
+
+def test_read_table(capsys, project_id):
+    read_table_bqstorage.read_table(your_project_id=project_id)
+    out, _ = capsys.readouterr()
+    assert "species_common_name" in out

--- a/samples/to_dataframe/requirements.txt
+++ b/samples/to_dataframe/requirements.txt
@@ -2,7 +2,7 @@ google-auth==1.32.0
 google-cloud-bigquery-storage==2.4.0
 google-cloud-bigquery==2.20.0
 pyarrow==4.0.1
-ipython==7.10.2; python_version > '3.0'
-ipython==5.9.0; python_version < '3.0'
-pandas==0.25.3; python_version > '3.0'
-pandas==0.24.2; python_version < '3.0'
+ipython==7.24.0; python_version > '3.6'
+ipython==7.16.1; python_version <= '3.6'
+pandas==1.2.5; python_version > '3.6'
+pandas==1.1.5; python_version <= '3.6'


### PR DESCRIPTION
In response to customer issue 179797311

This updates the code samples on https://cloud.google.com/bigquery/docs/bigquery-storage-python-pandas#objectives to include relevant imports.

Also:

- Add shared fixture for `project_id`
- Use `create_bqstorage_client` instead of manually creating one. Comment that this is the default.

Note: the samples in `main_test.py` are still there. We'll need to remove those once the docs have been updated.
