### PR TITLE
fix: resume read stream on `Unknown` transport-layer exception

### DIFF
--- a/google/cloud/bigquery_storage_v1/reader.py
+++ b/google/cloud/bigquery_storage_v1/reader.py
@@ -39,7 +39,12 @@ except ImportError:  # pragma: NO COVER
     pyarrow = None
 
 
-_STREAM_RESUMPTION_EXCEPTIONS = (google.api_core.exceptions.ServiceUnavailable,)
+_STREAM_RESUMPTION_EXCEPTIONS = (
+    google.api_core.exceptions.ServiceUnavailable,
+    # Caused by transport-level error. No status code was received.
+    # https://github.com/googleapis/python-bigquery-storage/issues/262
+    google.api_core.exceptions.Unknown,
+)
 
 # The Google API endpoint can unexpectedly close long-running HTTP/2 streams.
 # Unfortunately, this condition is surfaced to the caller as an internal error


### PR DESCRIPTION
These `Unknown` exceptions are occurring in long running tests of the Apache BEAM connector: https://github.com/apache/beam/pull/15185#issuecomment-893870561

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #262  🦕
