### PR TITLE
chore: migrate default branch to main

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,9 +1,9 @@
-# https://github.com/googleapis/repo-automation-bots/tree/master/packages/sync-repo-settings
-# Rules for master branch protection
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/sync-repo-settings
+# Rules for main branch protection
 branchProtectionRules:
 # Identifies the protection rule pattern. Name of the branch to be protected.
-# Defaults to `master`
-- pattern: master
+# Defaults to `main`
+- pattern: main
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -41,7 +41,7 @@ python3 -m pip install --upgrade --quiet nox
 python3 -m nox --version
 
 # If this is a continuous build, send the test log to the FlakyBot.
-# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/flakybot.
+# See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
   cleanup() {
     chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot

--- a/.kokoro/test-samples-impl.sh
+++ b/.kokoro/test-samples-impl.sh
@@ -80,7 +80,7 @@ for file in samples/**/requirements.txt; do
     EXIT=$?
 
     # If this is a periodic build, send the test log to the FlakyBot.
-    # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/flakybot.
+    # See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
     if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
       chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
       $KOKORO_GFILE_DIR/linux_amd64/flakybot

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ Contributing
 #. Make sure that your commit messages clearly describe the changes.
 #. Send a pull request. (Please Read: `Faster Pull Request Reviews`_)
 
-.. _Faster Pull Request Reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+.. _Faster Pull Request Reviews: https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 
 .. contents:: Here are some guidelines for hacking on the Google Cloud Client libraries.
 
@@ -50,9 +50,9 @@ You'll have to create a development environment using a Git checkout:
    # Configure remotes such that you can pull changes from the googleapis/python-bigquery-storage
    # repository into your local repository.
    $ git remote add upstream git@github.com:googleapis/python-bigquery-storage.git
-   # fetch and merge changes from upstream into master
+   # fetch and merge changes from upstream into main
    $ git fetch upstream
-   $ git merge upstream/master
+   $ git merge upstream/main
 
 Now your local repo is set up such that you will push changes to your GitHub
 repo, from which you can submit a pull request.
@@ -110,12 +110,12 @@ Coding Style
   variables::
 
    export GOOGLE_CLOUD_TESTING_REMOTE="upstream"
-   export GOOGLE_CLOUD_TESTING_BRANCH="master"
+   export GOOGLE_CLOUD_TESTING_BRANCH="main"
 
   By doing this, you are specifying the location of the most up-to-date
   version of ``python-bigquery-storage``. The the suggested remote name ``upstream``
   should point to the official ``googleapis`` checkout and the
-  the branch should be the main branch on that remote (``master``).
+  the branch should be the main branch on that remote (``main``).
 
 - This repository contains configuration for the
   `pre-commit <https://pre-commit.com/>`__ tool, which automates checking
@@ -209,7 +209,7 @@ The `description on PyPI`_ for the project comes directly from the
 ``README``. Due to the reStructuredText (``rst``) parser used by
 PyPI, relative links which will work on GitHub (e.g. ``CONTRIBUTING.rst``
 instead of
-``https://github.com/googleapis/python-bigquery-storage/blob/master/CONTRIBUTING.rst``)
+``https://github.com/googleapis/python-bigquery-storage/blob/main/CONTRIBUTING.rst``)
 may cause problems creating links or rendering the description.
 
 .. _description on PyPI: https://pypi.org/project/google-cloud-bigquery-storage
@@ -234,7 +234,7 @@ We support:
 
 Supported versions can be found in our ``noxfile.py`` `config`_.
 
-.. _config: https://github.com/googleapis/python-bigquery-storage/blob/master/noxfile.py
+.. _config: https://github.com/googleapis/python-bigquery-storage/blob/main/noxfile.py
 
 
 We also explicitly decided to support Python 3 beginning with version 3.6.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ Contributing
 #. Make sure that your commit messages clearly describe the changes.
 #. Send a pull request. (Please Read: `Faster Pull Request Reviews`_)
 
-.. _Faster Pull Request Reviews: https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+.. _Faster Pull Request Reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 
 .. contents:: Here are some guidelines for hacking on the Google Cloud Client libraries.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,8 +76,8 @@ source_suffix = [".rst", ".md"]
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = "google-cloud-bigquery-storage"
@@ -280,7 +280,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        root_doc,
         "google-cloud-bigquery-storage.tex",
         "google-cloud-bigquery-storage Documentation",
         author,
@@ -315,7 +315,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (
-        master_doc,
+        root_doc,
         "google-cloud-bigquery-storage",
         "google-cloud-bigquery-storage Documentation",
         [author],
@@ -334,7 +334,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "google-cloud-bigquery-storage",
         "google-cloud-bigquery-storage Documentation",
         author,

--- a/owlbot.py
+++ b/owlbot.py
@@ -26,10 +26,11 @@ default_version = "v1"
 
 for library in s.get_staging_dirs(default_version):
     # Work around gapic generator bug https://github.com/googleapis/gapic-generator-python/issues/902
-    s.replace(library / f"google/cloud/bigquery_storage_{library.name}/types/arrow.py",
-                r""".
+    s.replace(
+        library / f"google/cloud/bigquery_storage_{library.name}/types/arrow.py",
+        r""".
     Attributes:""",
-                r""".\n
+        r""".\n
     Attributes:""",
     )
 
@@ -99,11 +100,12 @@ for library in s.get_staging_dirs(default_version):
     # The append_rows method doesn't contain keyword arguments that build request
     # objects, so flattened tests are not needed and break with TypeError.
     s.replace(
-        library / f'tests/unit/gapic/bigquery_storage_{library.name}*/test_big_query_write.py',
+        library
+        / f"tests/unit/gapic/bigquery_storage_{library.name}*/test_big_query_write.py",
         r"(@[a-z.()\n]*\n)?(async )?"
         r"def test_append_rows_flattened[_a-z]*\(\):\n"
         r"( {4}.*|\n)+",
-        '\n',
+        "\n",
     )
 
     s.move(
@@ -148,5 +150,51 @@ s.move(
 
 python.py_samples(skip_readmes=True)
 
+# Remove the replacements below once
+# https://github.com/googleapis/synthtool/pull/1188 is merged
+
+# Update googleapis/repo-automation-bots repo to main in .kokoro/*.sh files
+s.replace(
+    ".kokoro/*.sh",
+    "repo-automation-bots/tree/master",
+    "repo-automation-bots/tree/main",
+)
+
+# Customize CONTRIBUTING.rst to replace master with main
+s.replace(
+    "CONTRIBUTING.rst",
+    "fetch and merge changes from upstream into master",
+    "fetch and merge changes from upstream into main",
+)
+
+s.replace(
+    "CONTRIBUTING.rst", "git merge upstream/master", "git merge upstream/main",
+)
+
+s.replace(
+    "CONTRIBUTING.rst",
+    """export GOOGLE_CLOUD_TESTING_BRANCH=\"master\"""",
+    """export GOOGLE_CLOUD_TESTING_BRANCH=\"main\"""",
+)
+
+s.replace(
+    "CONTRIBUTING.rst", "remote \(``master``\)", "remote (``main``)",
+)
+
+s.replace(
+    "CONTRIBUTING.rst", "blob/master/CONTRIBUTING.rst", "blob/main/CONTRIBUTING.rst",
+)
+
+s.replace(
+    "CONTRIBUTING.rst", "blob/master/noxfile.py", "blob/main/noxfile.py",
+)
+
+s.replace(
+    "docs/conf.py", "master_doc", "root_doc",
+)
+
+s.replace(
+    "docs/conf.py", "# The master toctree document.", "# The root toctree document.",
+)
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)


### PR DESCRIPTION
Fixes #280.

Supersedes #281. It turned out it's easier to merge the changes into `master` first and then just rename `master` to `main`, as opposed to manually creating the `main` branch, keep it in sync with `master`, changing all PR targets, etc.