### PR TITLE
fix: avoid failure if closing `AppendRowsStream` before opening

### DIFF
--- a/google/cloud/bigquery_storage_v1beta2/writer.py
+++ b/google/cloud/bigquery_storage_v1beta2/writer.py
@@ -264,14 +264,7 @@ class AppendRowsStream(object):
                 an "intentional" shutdown. This is passed to the callbacks
                 specified via :meth:`add_close_callback`.
         """
-        self._regular_shutdown_thread = threading.Thread(
-            name=_REGULAR_SHUTDOWN_THREAD_NAME,
-            daemon=True,
-            target=self._shutdown,
-            kwargs={"reason": reason},
-        )
-        self._regular_shutdown_thread.start()
-        self._regular_shutdown_thread.join()
+        self._shutdown(reason=reason)
 
     def _shutdown(self, reason: Optional[Exception] = None):
         """Run the actual shutdown sequence (stop the stream and all helper threads).

--- a/tests/unit/test_writer_v1beta2.py
+++ b/tests/unit/test_writer_v1beta2.py
@@ -20,6 +20,7 @@ import pytest
 from google.api_core import exceptions
 from google.cloud.bigquery_storage_v1beta2.services import big_query_write
 from google.cloud.bigquery_storage_v1beta2 import types as gapic_types
+from google.cloud.bigquery_storage_v1beta2 import exceptions as bqstorage_exceptions
 from google.protobuf import descriptor_pb2
 
 
@@ -42,6 +43,14 @@ def test_constructor_and_default_state(module_under_test):
 
     # Private state
     assert manager._client is mock_client
+
+
+def test_close_before_open(module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    manager = module_under_test.AppendRowsStream(mock_client, REQUEST_TEMPLATE)
+    manager.close()
+    with pytest.raises(bqstorage_exceptions.StreamClosedError):
+        manager.send(object())
 
 
 @mock.patch("google.api_core.bidi.BidiRpc", autospec=True)


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #302 🦕
