### PR TITLE
feat: add `AppendRowsStream` to use write API from v1 endpoint

### DIFF
--- a/google/cloud/bigquery_storage_v1/__init__.py
+++ b/google/cloud/bigquery_storage_v1/__init__.py
@@ -30,6 +30,10 @@ class BigQueryReadClient(client.BigQueryReadClient):
     __doc__ = client.BigQueryReadClient.__doc__
 
 
+class BigQueryWriteClient(client.BigQueryWriteClient):
+    __doc__ = client.BigQueryWriteClient.__doc__
+
+
 __all__ = (
     # google.cloud.bigquery_storage_v1
     "__version__",

--- a/google/cloud/bigquery_storage_v1/client.py
+++ b/google/cloud/bigquery_storage_v1/client.py
@@ -25,6 +25,7 @@ import google.api_core.gapic_v1.method
 
 from google.cloud.bigquery_storage_v1 import reader
 from google.cloud.bigquery_storage_v1.services import big_query_read
+from google.cloud.bigquery_storage_v1.services import big_query_write
 
 
 _SCOPES = (
@@ -135,3 +136,7 @@ class BigQueryReadClient(big_query_read.BigQueryReadClient):
             offset,
             {"retry": retry, "timeout": timeout, "metadata": metadata},
         )
+
+
+class BigQueryWriteClient(big_query_write.BigQueryWriteClient):
+    __doc__ = big_query_write.BigQueryWriteClient.__doc__

--- a/google/cloud/bigquery_storage_v1/exceptions.py
+++ b/google/cloud/bigquery_storage_v1/exceptions.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class StreamClosedError(Exception):
+    """Operation not supported while stream is closed."""

--- a/google/cloud/bigquery_storage_v1/writer.py
+++ b/google/cloud/bigquery_storage_v1/writer.py
@@ -28,9 +28,9 @@ from google.api_core import exceptions
 import google.api_core.retry
 import grpc
 
-from google.cloud.bigquery_storage_v1beta2 import exceptions as bqstorage_exceptions
-from google.cloud.bigquery_storage_v1beta2 import types as gapic_types
-from google.cloud.bigquery_storage_v1beta2.services import big_query_write
+from google.cloud.bigquery_storage_v1 import exceptions as bqstorage_exceptions
+from google.cloud.bigquery_storage_v1 import types as gapic_types
+from google.cloud.bigquery_storage_v1.services import big_query_write
 
 _LOGGER = logging.getLogger(__name__)
 _RPC_ERROR_THREAD_NAME = "Thread-OnRpcTerminated"

--- a/google/cloud/bigquery_storage_v1/writer.py
+++ b/google/cloud/bigquery_storage_v1/writer.py
@@ -77,9 +77,9 @@ class AppendRowsStream(object):
             initial_request_template:
                 Data to include in the first request sent to the stream. This
                 must contain
-                :attr:`google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.write_stream`
+                :attr:`google.cloud.bigquery_storage_v1.types.AppendRowsRequest.write_stream`
                 and
-                :attr:`google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.ProtoData.writer_schema`.
+                :attr:`google.cloud.bigquery_storage_v1.types.AppendRowsRequest.ProtoData.writer_schema`.
             metadata:
                 Extra headers to include when sending the streaming request.
         """
@@ -124,13 +124,13 @@ class AppendRowsStream(object):
         """Open an append rows stream.
 
         This is automatically called by the first call to the
-        :attr:`google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream.send`
+        :attr:`google.cloud.bigquery_storage_v1.writer.AppendRowsStream.send`
         method.
 
         Args:
             initial_request:
                 The initial request to start the stream. Must have
-                :attr:`google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.write_stream`
+                :attr:`google.cloud.bigquery_storage_v1.types.AppendRowsRequest.write_stream`
                 and ``proto_rows.writer_schema.proto_descriptor`` and
                 properties populated.
             timeout:

--- a/samples/snippets/append_rows_proto2.py
+++ b/samples/snippets/append_rows_proto2.py
@@ -20,9 +20,9 @@ This code sample demonstrates using the low-level generated client for Python.
 import datetime
 import decimal
 
-from google.cloud import bigquery_storage_v1beta2
-from google.cloud.bigquery_storage_v1beta2 import types
-from google.cloud.bigquery_storage_v1beta2 import writer
+from google.cloud import bigquery_storage_v1
+from google.cloud.bigquery_storage_v1 import types
+from google.cloud.bigquery_storage_v1 import writer
 from google.protobuf import descriptor_pb2
 
 # If you make updates to the sample_data.proto protocol buffers definition,
@@ -36,13 +36,13 @@ from . import sample_data_pb2
 
 def append_rows_proto2(project_id: str, dataset_id: str, table_id: str):
     """Create a write stream, write some sample data, and commit the stream."""
-    write_client = bigquery_storage_v1beta2.BigQueryWriteClient()
+    write_client = bigquery_storage_v1.BigQueryWriteClient()
     parent = write_client.table_path(project_id, dataset_id, table_id)
     write_stream = types.WriteStream()
 
     # When creating the stream, choose the type. Use the PENDING type to wait
     # until the stream is committed before it is visible. See:
-    # https://cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1beta2#google.cloud.bigquery.storage.v1beta2.WriteStream.Type
+    # https://cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1#google.cloud.bigquery.storage.v1.WriteStream.Type
     write_stream.type_ = types.WriteStream.Type.PENDING
     write_stream = write_client.create_write_stream(
         parent=parent, write_stream=write_stream

--- a/tests/system/test_writer.py
+++ b/tests/system/test_writer.py
@@ -15,14 +15,14 @@
 from google.api_core import exceptions
 import pytest
 
-from google.cloud.bigquery_storage_v1beta2 import types as gapic_types
+from google.cloud.bigquery_storage_v1 import types as gapic_types
 
 
 @pytest.fixture(scope="session")
 def bqstorage_write_client(credentials):
-    from google.cloud import bigquery_storage_v1beta2
+    from google.cloud import bigquery_storage_v1
 
-    return bigquery_storage_v1beta2.BigQueryWriteClient(credentials=credentials)
+    return bigquery_storage_v1.BigQueryWriteClient(credentials=credentials)
 
 
 def test_append_rows_with_invalid_stream_name_fails_fast(bqstorage_write_client):

--- a/tests/unit/test_writer_v1.py
+++ b/tests/unit/test_writer_v1.py
@@ -1,0 +1,158 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import freezegun
+import pytest
+
+from google.api_core import exceptions
+from google.cloud.bigquery_storage_v1.services import big_query_write
+from google.cloud.bigquery_storage_v1 import types as gapic_types
+from google.cloud.bigquery_storage_v1 import exceptions as bqstorage_exceptions
+from google.protobuf import descriptor_pb2
+
+
+REQUEST_TEMPLATE = gapic_types.AppendRowsRequest()
+
+
+@pytest.fixture(scope="module")
+def module_under_test():
+    from google.cloud.bigquery_storage_v1 import writer
+
+    return writer
+
+
+def test_constructor_and_default_state(module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    manager = module_under_test.AppendRowsStream(mock_client, REQUEST_TEMPLATE)
+
+    # Public state
+    assert manager.is_active is False
+
+    # Private state
+    assert manager._client is mock_client
+
+
+def test_close_before_open(module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    manager = module_under_test.AppendRowsStream(mock_client, REQUEST_TEMPLATE)
+    manager.close()
+    with pytest.raises(bqstorage_exceptions.StreamClosedError):
+        manager.send(object())
+
+
+@mock.patch("google.api_core.bidi.BidiRpc", autospec=True)
+@mock.patch("google.api_core.bidi.BackgroundConsumer", autospec=True)
+def test_initial_send(background_consumer, bidi_rpc, module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    request_template = gapic_types.AppendRowsRequest(
+        write_stream="stream-name-from-REQUEST_TEMPLATE",
+        offset=0,
+        proto_rows=gapic_types.AppendRowsRequest.ProtoData(
+            writer_schema=gapic_types.ProtoSchema(
+                proto_descriptor=descriptor_pb2.DescriptorProto()
+            )
+        ),
+    )
+    manager = module_under_test.AppendRowsStream(mock_client, request_template)
+    type(bidi_rpc.return_value).is_active = mock.PropertyMock(
+        return_value=(False, True)
+    )
+    proto_rows = gapic_types.ProtoRows()
+    proto_rows.serialized_rows.append(b"hello, world")
+    initial_request = gapic_types.AppendRowsRequest(
+        write_stream="this-is-a-stream-resource-path",
+        offset=42,
+        proto_rows=gapic_types.AppendRowsRequest.ProtoData(rows=proto_rows),
+    )
+
+    future = manager.send(initial_request)
+
+    assert isinstance(future, module_under_test.AppendRowsFuture)
+    background_consumer.assert_called_once_with(manager._rpc, manager._on_response)
+    background_consumer.return_value.start.assert_called_once()
+    assert manager._consumer == background_consumer.return_value
+
+    # Make sure the request template and the first request are merged as
+    # expected. Needs to be especially careful that nested properties such as
+    # writer_schema and rows are merged as expected.
+    expected_request = gapic_types.AppendRowsRequest(
+        write_stream="this-is-a-stream-resource-path",
+        offset=42,
+        proto_rows=gapic_types.AppendRowsRequest.ProtoData(
+            writer_schema=gapic_types.ProtoSchema(
+                proto_descriptor=descriptor_pb2.DescriptorProto()
+            ),
+            rows=proto_rows,
+        ),
+    )
+    bidi_rpc.assert_called_once_with(
+        start_rpc=mock_client.append_rows,
+        initial_request=expected_request,
+        # Extra header is required to route requests to the correct location.
+        metadata=(
+            ("x-goog-request-params", "write_stream=this-is-a-stream-resource-path"),
+        ),
+    )
+
+    bidi_rpc.return_value.add_done_callback.assert_called_once_with(
+        manager._on_rpc_done
+    )
+    assert manager._rpc == bidi_rpc.return_value
+
+    manager._consumer.is_active = True
+    assert manager.is_active is True
+
+
+@mock.patch("google.api_core.bidi.BidiRpc", autospec=True)
+@mock.patch("google.api_core.bidi.BackgroundConsumer", autospec=True)
+def test_initial_send_with_timeout(background_consumer, bidi_rpc, module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    manager = module_under_test.AppendRowsStream(mock_client, REQUEST_TEMPLATE)
+    type(bidi_rpc.return_value).is_active = mock.PropertyMock(return_value=False)
+    type(background_consumer.return_value).is_active = mock.PropertyMock(
+        return_value=False
+    )
+    initial_request = gapic_types.AppendRowsRequest(
+        write_stream="this-is-a-stream-resource-path"
+    )
+
+    with pytest.raises(exceptions.Unknown), freezegun.freeze_time(
+        auto_tick_seconds=module_under_test._DEFAULT_TIMEOUT + 1
+    ):
+        manager.send(initial_request)
+
+
+def test_future_done_false(module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    manager = module_under_test.AppendRowsStream(mock_client, REQUEST_TEMPLATE)
+    future = module_under_test.AppendRowsFuture(manager)
+    assert not future.done()
+
+
+def test_future_done_true_with_result(module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    manager = module_under_test.AppendRowsStream(mock_client, REQUEST_TEMPLATE)
+    future = module_under_test.AppendRowsFuture(manager)
+    future.set_result(object())
+    assert future.done()
+
+
+def test_future_done_true_with_exception(module_under_test):
+    mock_client = mock.create_autospec(big_query_write.BigQueryWriteClient)
+    manager = module_under_test.AppendRowsStream(mock_client, REQUEST_TEMPLATE)
+    future = module_under_test.AppendRowsFuture(manager)
+    future.set_exception(ValueError())
+    assert future.done()


### PR DESCRIPTION
This is just a duplicate of the class in the v1beta2 endpoint.

I see for reads we tried to be clever by using the v1 version from the v1beta2 endpoint, but it would be harder to do with the write API. The `initial_request_template` parameter means that we need to make sure for certain that we are using the generated types for the correct endpoint.

Since "beta" is clearly in the endpoint and import name, I think leaving the v1beta2 writer module as-is, with additional features and fixes only added to v1 makes some sense. Alternatively, we could add some tests to ensure these classes stay in sync?