### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-bigquery-storage",
     "api_id": "bigquerystorage.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
-    "codeowner_team": ""
+    "default_version": "v1",
+    "codeowner_team": "@googleapis/api-bigquery"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "bigquerystorage",
-  "name_pretty": "Google BigQuery Storage",
-  "product_documentation": "https://cloud.google.com/bigquery/docs/reference/storage/",
-  "client_documentation": "https://googleapis.dev/python/bigquerystorage/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_COMBO",
-  "repo": "googleapis/python-bigquery-storage",
-  "distribution_name": "google-cloud-bigquery-storage",
-  "api_id": "bigquerystorage.googleapis.com",
-  "requires_billing": true
+    "name": "bigquerystorage",
+    "name_pretty": "Google BigQuery Storage",
+    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/storage/",
+    "client_documentation": "https://googleapis.dev/python/bigquerystorage/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_COMBO",
+    "repo": "googleapis/python-bigquery-storage",
+    "distribution_name": "google-cloud-bigquery-storage",
+    "api_id": "bigquerystorage.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
Set codeowner_team to googleapis/api-bigquery as codeowner. Set default_version to v1. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114