### PR TITLE
Revert "chore: update doc links from googleapis.dev to cloud.google.com"

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigquerystorage",
     "name_pretty": "Google BigQuery Storage",
     "product_documentation": "https://cloud.google.com/bigquery/docs/reference/storage/",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/bigquerystorage/latest",
+    "client_documentation": "https://googleapis.dev/python/bigquerystorage/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for BigQuery Storage API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-storage.svg
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
 .. _BigQuery Storage API: https://cloud.google.com/bigquery/docs/reference/storage/
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerystorage/latest
+.. _Client Library Documentation: https://googleapis.dev/python/bigquerystorage/latest
 .. _Product Documentation: https://cloud.google.com/bigquery/docs/reference/storage/
 
 Quick Start


### PR DESCRIPTION
Reverts googleapis/python-bigquery-storage#354

Missing manual clients here: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.client

In google-cloud-bigquery-storage, we subclass the generated clients and override the `read_rows` method to have a slightly different signature.