### PR TITLE
fix: remove libcst as a required dependency

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,11 +132,12 @@ wrapper around the auto-generated `read_rows()` method.
 python3 -m pip install google-cloud-bigquery-storage
 ```
 
-* The script `fixup_storage_v1_keywords.py` is shipped with the library. It expects
-an input directory (with the code to convert) and an empty destination directory.
+* The script `fixup_storage_v1_keywords.py` is shipped with the library. It
+requires `libcst` to be installed. It expects an input directory (with the code
+to convert) and an empty destination directory.
 
 ```sh
-$ scripts/fixup_storage_v1_keywords.py --input-directory .samples/ --output-directory samples/
+$ fixup_bigquery_storage_v1_keywords.py --input-directory .samples/ --output-directory samples/
 ```
 
 **Before:**

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,7 +132,7 @@ wrapper around the auto-generated `read_rows()` method.
 python3 -m pip install google-cloud-bigquery-storage
 ```
 
-* The script `fixup_storage_v1_keywords.py` is shipped with the library. It
+* The script `fixup_bigquery_storage_v1_keywords.py` is shipped with the library. It
 requires `libcst` to be installed. It expects an input directory (with the code
 to convert) and an empty destination directory.
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ dependencies = [
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
     "proto-plus >= 1.18.0",
-    "libcst >= 0.2.5",
 ]
 extras = {
     "pandas": ["pandas>=0.21.1"],


### PR DESCRIPTION
libcst is only used for a one-off "fixup" script. It’s not necessary to always depend on it.

It caused an issue on one project as old libcst versions don't ship macOS M1 wheels, and it took time to figure this out.

(Also the instructions for using the fixup script were incorrect.)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [nope] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [I hope so] Ensure the tests and linter pass
- [it shouldn't] Code coverage does not decrease (if any source code was changed)
- [yes] Appropriate docs were updated (if necessary)

Fixes #395 🦕 
