### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,0 +1,14 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+google-api-core==1.31.5
+proto-plus==1.18.0
+libcst==0.2.5
+fastavro==0.21.2
+pandas==0.21.1
+pyarrow==0.15.0
+protobuf==3.19.0

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -9,6 +9,6 @@ google-api-core==1.31.5
 proto-plus==1.18.0
 libcst==0.2.5
 fastavro==0.21.2
-pandas==0.21.1
+pandas==0.23.2
 pyarrow==0.15.0
 protobuf==3.19.0

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -9,6 +9,6 @@ google-api-core==1.31.5
 proto-plus==1.18.0
 libcst==0.2.5
 fastavro==0.21.2
-pandas==0.23.2
+pandas==1.0.5
 pyarrow==0.15.0
 protobuf==3.19.0


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6