### PR TITLE
test: Remove Use Of check_datetimelike_compat Flag

### DIFF
--- a/tests/unit/test_reader_v1.py
+++ b/tests/unit/test_reader_v1.py
@@ -477,9 +477,7 @@ def test_to_dataframe_w_scalars(class_under_test, mock_gapic_client):
     )
     pandas.testing.assert_series_equal(
         got_ts.reset_index(drop=True),
-        expected_ts.reset_index(drop=True),
-        check_dtype=False,  # fastavro's UTC means different dtype
-        check_datetimelike_compat=True,
+        expected_ts.reset_index(drop=True).astype(got_ts.dtype),
     )
 
 


### PR DESCRIPTION
Fixes #479 🦕
