### PR TITLE
bug: add exception case to support fastavro 1.8.4

### DIFF
--- a/google/cloud/bigquery_storage_v1/reader.py
+++ b/google/cloud/bigquery_storage_v1/reader.py
@@ -712,7 +712,7 @@ class _AvroStreamParser(_StreamParser):
                 # TODO: Parse DATETIME into datetime.datetime (no timezone),
                 #       instead of as a string.
                 yield fastavro.schemaless_reader(messageio, self._fastavro_schema)
-            except StopIteration:
+            except (StopIteration, EOFError):
                 break  # Finished with message
 
 


### PR DESCRIPTION
[version 1.8.4 of fastavro](https://github.com/fastavro/fastavro/blob/c13bb3399fd75b65c28200a607043072b60ec425/ChangeLog#L1) was released on 10/03/2023, leading to a group of bugs under #654. This was caused by changing the error from `StopIteration` to `EOFError` in [this commit](https://github.com/fastavro/fastavro/pull/703), and the python-bigquery-storage repo does not catch this as an exception. This PR adds `EOFError` to the exception.

Expected to be a solution for #654, but it should be closed by flakybot once the tests no longer fail. 🦕
