### PR TITLE
testing: use arbitrary equality for pinned requirement versions

### DIFF
--- a/samples/quickstart/requirements-test.txt
+++ b/samples/quickstart/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest==7.4.3; python_version == '3.7'
+pytest===7.4.3; python_version == '3.7'
 pytest==8.1.1; python_version >= '3.8'

--- a/samples/snippets/requirements-test.txt
+++ b/samples/snippets/requirements-test.txt
@@ -1,3 +1,3 @@
 google-cloud-testutils==1.4.0
-pytest==7.4.3; python_version == '3.7'
+pytest===7.4.3; python_version == '3.7'
 pytest==8.1.1; python_version >= '3.8'

--- a/samples/to_dataframe/requirements-test.txt
+++ b/samples/to_dataframe/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest==7.4.3; python_version == '3.7'
+pytest===7.4.3; python_version == '3.7'
 pytest==8.1.1; python_version >= '3.8'

--- a/samples/to_dataframe/requirements.txt
+++ b/samples/to_dataframe/requirements.txt
@@ -1,11 +1,11 @@
 google-auth==2.29.0
 google-cloud-bigquery-storage==2.24.0
 google-cloud-bigquery==3.20.1
-pyarrow==12.0.1; python_version == '3.7'
+pyarrow===12.0.1; python_version == '3.7'
 pyarrow==15.0.2; python_version >= '3.8'
 ipython===7.31.1; python_version == '3.7'
 ipython===8.10.0; python_version == '3.8'
-ipython==8.18.1; python_version == '3.9'
+ipython===8.18.1; python_version == '3.9'
 ipython==8.23.0; python_version >= '3.10'
 ipywidgets==8.1.2
 pandas===1.3.5; python_version == '3.7'


### PR DESCRIPTION
Similar to https://github.com/googleapis/python-db-dtypes-pandas/pull/262, using arbitrary equality (`===`) for pinned requirements so dependabot doesn't attempt to update them.
