### PR TITLE
fix(deps): update proto-plus to >=1.25 for Python 3.13 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ dependencies = [
     "google-auth >= 2.14.1, <3.0.0dev",
     "proto-plus >= 1.22.0, <2.0.0dev",
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",
+    "proto-plus >= 1.25.0, <2.0.0dev; python_version>='3.13'",
     "protobuf>=3.20.2,<6.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 extras = {


### PR DESCRIPTION
Fixes #842  🦕
