### PR TITLE
test: make pyarrow sample less flaky

### DIFF
--- a/samples/conftest.py
+++ b/samples/conftest.py
@@ -14,6 +14,7 @@
 
 import datetime
 import os
+import random
 
 import pytest
 
@@ -28,8 +29,9 @@ def dataset(project_id):
     from google.cloud import bigquery
 
     client = bigquery.Client()
-    dataset_suffix = datetime.datetime.now().strftime("%y%m%d_%H%M%S")
-    dataset_name = "samples_tests_" + dataset_suffix
+    dataset_time = datetime.datetime.now().strftime("%y%m%d_%H%M%S")
+    suffix = f"_{(random.randint(0, 99)):02d}"
+    dataset_name = "samples_tests_" + dataset_time + suffix
 
     dataset_id = "{}.{}".format(project_id, dataset_name)
     dataset = bigquery.Dataset(dataset_id)

--- a/samples/conftest.py
+++ b/samples/conftest.py
@@ -29,6 +29,9 @@ def dataset(project_id):
     from google.cloud import bigquery
 
     client = bigquery.Client()
+
+    # Add a random suffix to dataset name to avoid conflict, because we run
+    # a samples test on each supported Python version almost at the same time.
     dataset_time = datetime.datetime.now().strftime("%y%m%d_%H%M%S")
     suffix = f"_{(random.randint(0, 99)):02d}"
     dataset_name = "samples_tests_" + dataset_time + suffix


### PR DESCRIPTION
The samples test has been a bit flaky because all the python versions create a dataset at the same time, and that sometimes causes a conflict. This PR adds a short random suffix to make this less likely to happen.