### PR TITLE
fix: separate create_stream() in pyarrow sample

### DIFF
--- a/samples/pyarrow/append_rows_with_arrow.py
+++ b/samples/pyarrow/append_rows_with_arrow.py
@@ -183,6 +183,7 @@ def verify_result(client, table, futures):
     # Verify table size.
     query = client.query(f"SELECT COUNT(1) FROM `{bq_table}`;")
     query_result = query.result().to_dataframe()
+
     # There might be extra rows due to retries.
     assert query_result.iloc[0, 0] >= TABLE_LENGTH
 

--- a/samples/pyarrow/append_rows_with_arrow.py
+++ b/samples/pyarrow/append_rows_with_arrow.py
@@ -197,7 +197,7 @@ def main(project_id, dataset):
 
     # Create BigQuery table.
     bq_table = make_table(project_id, dataset.dataset_id, bq_client)
-    
+
     # Generate local PyArrow table.
     pa_table = generate_pyarrow_table()
 

--- a/samples/pyarrow/append_rows_with_arrow.py
+++ b/samples/pyarrow/append_rows_with_arrow.py
@@ -174,10 +174,6 @@ def generate_write_requests(pyarrow_table):
         yield request
 
 
-def append_rows(stream, request):
-    return stream.send(request)
-
-
 def verify_result(client, table, futures):
     bq_table = client.get_table(table)
 
@@ -214,7 +210,7 @@ def main(project_id, dataset):
     # Send requests.
     futures = []
     for request in requests:
-        future = append_rows(stream, request)
+        future = stream.send(request)
         futures.append(future)
         future.result()  # Optional, will block until writing is complete.
 


### PR DESCRIPTION
While using the pyarrow sample, some people call append_rows() repeatedly, leading to a new connection every time it is called. This PR makes the call hierarchy flatter by moving create_stream() outside append_rows() (and then deleting append_rows()), making it clearer how to use this library.

- [x] move create_stream() to outside of append_rows(), so user does not open a new connection every time append_rows() is called
- [x] move the pyarrow sample into the samples/snippets folder

