### PR TITLE
chore: remove redundant code

### DIFF
--- a/google/cloud/bigquery_storage_v1/types/__init__.py
+++ b/google/cloud/bigquery_storage_v1/types/__init__.py
@@ -68,7 +68,6 @@ __all__ = (
     "StorageError",
     "StreamStats",
     "ThrottleState",
-    "DataFormat",
     "ReadSession",
     "ReadStream",
     "WriteStream",

--- a/google/cloud/bigquery_storage_v1beta2/types/__init__.py
+++ b/google/cloud/bigquery_storage_v1beta2/types/__init__.py
@@ -65,7 +65,6 @@ __all__ = (
     "StorageError",
     "StreamStats",
     "ThrottleState",
-    "DataFormat",
     "ReadSession",
     "ReadStream",
     "WriteStream",

--- a/owlbot.py
+++ b/owlbot.py
@@ -76,18 +76,6 @@ for library in s.get_staging_dirs(default_version):
             ),
         )
 
-        # The DataFormat enum is not exposed in bigquery_storage_v1/types, add it there.
-        assert 1 == s.replace(
-            library / f"google/cloud/bigquery_storage_{library.name}*/types/__init__.py",
-            r"from \.stream import \(",
-            "\\g<0>\n    DataFormat,",
-        )
-        assert 1 == s.replace(
-            library / f"google/cloud/bigquery_storage_{library.name}*/types/__init__.py",
-            r"""["']ReadSession["']""",
-            '"DataFormat",\n    \\g<0>',
-        )
-
         # Expose handwritten classes AppendRowsStream and ReadRowsStream here.
         assert 1 == s.replace(
             library / "google/cloud/bigquery_storage/__init__.py",


### PR DESCRIPTION
The comment below states `The DataFormat enum is not exposed in bigquery_storage_v1/types, add it there` but it is already part of `bigquery_storage_v1/types`

https://github.com/googleapis/python-bigquery-storage/blob/2a6daa16a5a6fe76901084748f909eba3ffb4c30/owlbot.py#L79-L89

This code causes `DataFormat` to appear twice in `**/types/__init__.py`

https://github.com/googleapis/python-bigquery-storage/blob/2a6daa16a5a6fe76901084748f909eba3ffb4c30/google/cloud/bigquery_storage_v1/types/__init__.py#L71-L75

https://github.com/googleapis/python-bigquery-storage/blob/2a6daa16a5a6fe76901084748f909eba3ffb4c30/google/cloud/bigquery_storage_v1beta2/types/__init__.py#L68-L72

See the generated code here which shows `DataFormat` already exists in `**/types/__init__.py`

https://github.com/googleapis/googleapis-gen/blob/0c329e8511aa92a534987082babc89f9364a341b/google/cloud/bigquery/storage/v1/bigquery-storage-v1-py/google/cloud/bigquery_storage_v1/types/__init__.py#L55

https://github.com/googleapis/googleapis-gen/blob/0c329e8511aa92a534987082babc89f9364a341b/google/cloud/bigquery/storage/v1beta2/bigquery-storage-v1beta2-py/google/cloud/bigquery_storage_v1beta2/types/__init__.py#L53


See related commits in https://github.com/googleapis/google-cloud-python/pull/14361

https://github.com/googleapis/google-cloud-python/pull/14361/commits/e4564dcce6b76c3208d4a0702dbdd25903bc980c
https://github.com/googleapis/google-cloud-python/pull/14361/commits/685e1e86942188fa467de8f3d43e163d10aa98db